### PR TITLE
STAR-77 Change the frontend .prettierrc file from dist to build

### DIFF
--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,3 +1,3 @@
 node_modules
-dist
+build
 .prettierrc


### PR DESCRIPTION
- The default **Vite** setup uses `dist` as the output build folder
- I explicitly changed that output build folder to `build` in the `client/vite.config.js`
- I need to now reflect that in the `client/.prettierignore` file

This was an oversight of mine