### PR TITLE
STAR-78 add .DS_Store to gitignore in server folder

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,4 +1,5 @@
 node_modules
-dist
 build
+dist
 .env*
+.DS_Store


### PR DESCRIPTION
- MacOS automatically adds .DS_Store files to all folders
- Add this to the `.gitignore` of the `server` folder