### PR TITLE
STAR-89 Fix to allow Chrome to store Cookies

### DIFF
--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -127,7 +127,7 @@ export const idTokenHandler = async (req: Request, res: Response) => {
   // set the JWT as an HTTP-Only Cookie
   res.cookie("customJWT", customJWT, {
     httpOnly: true, // set the cookie as HTTP-Only
-    secure: false, // enable "secure" to use HTTPS
+    secure: true, // enable "secure" to use HTTPS
     sameSite: "none", // "sameSite" determines how the cookie is sent with Cross-Origin Requests "strict" | "lax" | "none"
     maxAge: 3600000 // set expiry of 1 hour to match the customJWT
   });
@@ -145,7 +145,7 @@ export const idTokenHandler = async (req: Request, res: Response) => {
 
   res.cookie("user", userCookieData, {
     httpOnly: false,
-    secure: false,
+    secure: true,
     sameSite: "none",
     maxAge: 3600000
   });


### PR DESCRIPTION
- Chrome was not storing the Cookies because of their attributes

![image (6)](https://github.com/fazbazjaz/star/assets/61154071/aa22dc8c-4c44-4df8-8b73-394b01e780bf)

- Toggled the Cookies to use `secure: true`

- Fixes the issue @softacoder and @farzaneh-haghani were experiencing where Chrome 
wouldn't login properly because it wasn't storing the Cookies



