### PR TITLE
STAR-95 MaterialUI CSS Baseline, Roboto Font, App Grid Wrapper, Refactor Home/Hero

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fontsource/roboto": "^5.0.8",
         "@googlemaps/js-api-loader": "^1.16.2",
         "@mui/icons-material": "^5.14.18",
         "@mui/material": "^5.14.18",
@@ -989,6 +990,11 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.8.tgz",
+      "integrity": "sha512-XxPltXs5R31D6UZeLIV1td3wTXU3jzd3f2DLsXI8tytMGBkIsGcc9sIyiupRtA8y73HAhuSCeweOoBqf6DbWCA=="
     },
     "node_modules/@googlemaps/js-api-loader": {
       "version": "1.16.2",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@fontsource/roboto": "^5.0.8",
     "@googlemaps/js-api-loader": "^1.16.2",
     "@mui/icons-material": "^5.14.18",
     "@mui/material": "^5.14.18",

--- a/client/src/components/Hero.jsx
+++ b/client/src/components/Hero.jsx
@@ -1,36 +1,24 @@
 import { Box, Typography } from "@mui/material";
 
 const Hero = () => {
-  const heroBackgroundImage = "/images/background-001.jpg";
-
   return (
     <Box
-      overflow={"hidden"}
-      border={1}
-      sx={{
-        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url(${heroBackgroundImage})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center center",
-        backgroundRepeat: "no-repeat",
-      }}>
-      <Box
-        display={"flex"}
-        flexDirection={"column"}
-        alignItems={"center"}
-        py={6}
-        color={"white"}>
-        <Typography align={"center"} variant={"h2"} marked={"center"}>
-          STAR - Situation, Task, Action and Result
-        </Typography>
-        <Typography variant={"h5"} align={"center"} mt={6}>
-          STAR solves a business problem.
-        </Typography>
-        <Typography mt={4}>
-          At CodeYourFuture, trainees keep a brag diary to build up a bank of
-          examples of their skills, knowledge and capabilities.
-        </Typography>
-        <Typography mt={4}>Build your future</Typography>
-      </Box>
+      display={"flex"}
+      flexDirection={"column"}
+      alignItems={"center"}
+      py={6}
+      color={"white"}>
+      <Typography align={"center"} variant={"h2"} marked={"center"}>
+        STAR - Situation, Task, Action and Result
+      </Typography>
+      <Typography variant={"h5"} align={"center"} mt={6}>
+        STAR solves a business problem.
+      </Typography>
+      <Typography mt={4}>
+        At CodeYourFuture, trainees keep a brag diary to build up a bank of
+        examples of their skills, knowledge and capabilities.
+      </Typography>
+      <Typography mt={4}>Build your future</Typography>
     </Box>
   );
 };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,11 +3,10 @@
 }
 
 body {
-  /* temporary color to differentiate between <body> and <div id="root"> */
-  background-color: #bfbfbf;
+  /* placeholder */
 }
 
 /* the <div id="root"> that contains the React Application */
 #root {
-  background-color: white;
+  /* placeholder */
 }

--- a/client/src/layouts/RootLayout.jsx
+++ b/client/src/layouts/RootLayout.jsx
@@ -1,19 +1,32 @@
 import { Outlet } from "react-router-dom";
+import CssBaseline from "@mui/material/CssBaseline";
+import "@fontsource/roboto/300.css";
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
+import "@fontsource/roboto/700.css";
 import AuthProvider from "../context/AuthContext";
 import AuthState from "../components/AuthState";
 import Header from "../components/Header";
 import Navigation from "../components/Navigation";
 import Footer from "../components/Footer";
+import { Box } from "@mui/material";
 
 const RootLayout = () => {
   return (
     <>
       <AuthProvider>
-        <AuthState />
-        <Header />
-        <Navigation />
-        <Outlet />
-        <Footer />
+        <CssBaseline />
+        <Box
+          minHeight={"100vh"}
+          display={"grid"}
+          gridTemplateRows={"auto auto auto 1fr auto"}
+          border={4}>
+          <AuthState />
+          <Header />
+          <Navigation />
+          <Outlet />
+          <Footer />
+        </Box>
       </AuthProvider>
     </>
   );

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -3,8 +3,16 @@ import Hero from "../components/Hero";
 import Map from "../components/Map";
 
 const Home = () => {
+  const homeBackgroundImage = "/images/background-001.jpg";
+
   return (
-    <Box border={1}>
+    <Box
+      sx={{
+        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url(${homeBackgroundImage})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center center",
+        backgroundRepeat: "no-repeat",
+      }}>
       <Hero />
       <Map />
     </Box>


### PR DESCRIPTION
- added CSS Baseline from MaterialUI to apply CSS Reset
- added Roboto Font dependency per MaterialUI documentation
- Wrapped the App in a Box with min height 100vh and CSS Grid of 5 Rows, where the Outlet is 1fr and the rest are auto, to make the footer stay at the bottom of the Page, and the Outlet (Pages) always expand to the height of the Browser Window.
- Minor refactor/optimisation on Home and Hero