### PR TITLE
STAR-109 Refactor Frontend to Abstract Away API Calls

### DIFF
--- a/client/src/api/deleteQuestion.js
+++ b/client/src/api/deleteQuestion.js
@@ -1,0 +1,23 @@
+const deleteQuestion = async (questionId) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    }
+  );
+  // console.log("deleteQuestion response", response);
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText} : deleteQuestion failed`
+    );
+  }
+  const data = await response.json();
+  // console.log("deleteQuestion data", data);
+  return data;
+};
+
+export default deleteQuestion;

--- a/client/src/api/getAllQuestions.js
+++ b/client/src/api/getAllQuestions.js
@@ -1,0 +1,15 @@
+const getAllQuestions = async () => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions`,
+    { credentials: "include" }
+  );
+  // console.log("fetchAllQuestionsData response:", response);
+  if (!response.ok) {
+    throw new Error("fetchAllQuestions failed");
+  }
+  const data = await response.json();
+  // console.log("fetchAllQuestionsData data:", data);
+  return data;
+};
+
+export default getAllQuestions;

--- a/client/src/api/getAllQuestionsByUserId.js
+++ b/client/src/api/getAllQuestionsByUserId.js
@@ -1,0 +1,15 @@
+const getAllQuestionsByUserId = async (userId) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions/user/${userId}`,
+    { credentials: "include" }
+  );
+  // console.log("fetchUserQuestions response:", response);
+  if (!response.ok) {
+    throw new Error("fetchUserQuestions failed");
+  }
+  const data = await response.json();
+  // console.log("fetchUserQuestions data:", data);
+  return data;
+};
+
+export default getAllQuestionsByUserId;

--- a/client/src/api/getQuestionById.js
+++ b/client/src/api/getQuestionById.js
@@ -1,0 +1,15 @@
+const getQuestionById = async (questionId) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}`,
+    { credentials: "include" }
+  );
+  // console.log("fetchQuestionData response:", response);
+  if (!response.ok) {
+    throw new Error("fetchQuestion failed");
+  }
+  const data = await response.json();
+  // console.log("fetchQuestionData data:", data);
+  return data;
+};
+
+export default getQuestionById;

--- a/client/src/api/postAnswer.js
+++ b/client/src/api/postAnswer.js
@@ -1,0 +1,24 @@
+const postAnswer = async (questionId, answer) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}/answers`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(answer),
+    }
+  );
+  // console.log("postAnswer response", response);
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText} : postAnswer failed`
+    );
+  }
+  const data = await response.json();
+  // console.log("postAnswer data", data);
+  return data;
+};
+
+export default postAnswer;

--- a/client/src/api/postComment.js
+++ b/client/src/api/postComment.js
@@ -1,0 +1,26 @@
+const postComment = async (questionId, answerId, comment) => {
+  const response = await fetch(
+    `${
+      import.meta.env.VITE_SERVER_URL
+    }/api/questions/${questionId}/answers/${answerId}/comments`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({ comment }),
+    }
+  );
+  // console.log("postComment response", response);
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText} : postComment failed`
+    );
+  }
+  const data = await response.json();
+  // console.log("postComment data", data);
+  return data;
+};
+
+export default postComment;

--- a/client/src/api/postQuestion.js
+++ b/client/src/api/postQuestion.js
@@ -1,0 +1,24 @@
+const postQuestion = async (question) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({ question }),
+    }
+  );
+  // console.log("postQuestion response", response);
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText} : postQuestion failed`
+    );
+  }
+  const data = await response.json();
+  // console.log("postQuestion data", data);
+  return data;
+};
+
+export default postQuestion;

--- a/client/src/api/putQuestion.js
+++ b/client/src/api/putQuestion.js
@@ -1,0 +1,24 @@
+const putQuestion = async (questionId, editedQuestion) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}`,
+    {
+      method: "PUT",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ question: editedQuestion }),
+    }
+  );
+  // console.log("putQuestion response:", response);
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText} : editedQuestion failed`
+    );
+  }
+  const data = await response.json();
+  // console.log("putQuestion data:", data);
+  return data;
+};
+
+export default putQuestion;

--- a/client/src/components/AddAnswerForm.jsx
+++ b/client/src/components/AddAnswerForm.jsx
@@ -10,6 +10,7 @@ import {
 import RateReviewRoundedIcon from "@mui/icons-material/RateReviewRounded";
 import ArrowForwardIosRoundedIcon from "@mui/icons-material/ArrowForwardIosRounded";
 import SendIcon from "@mui/icons-material/Send";
+import postAnswer from "../api/postAnswer";
 import {
   consistentBorder,
   consistentBorderRadius,
@@ -27,7 +28,6 @@ const AddAnswerForm = ({ questionId, setShowAddAnswerForm }) => {
     action: "",
     result: "",
   });
-
   const [answerValidation, setAnswerValidation] = useState({
     situation: undefined,
     task: undefined,
@@ -49,40 +49,12 @@ const AddAnswerForm = ({ questionId, setShowAddAnswerForm }) => {
     });
   };
 
-  const postAnswer = async () => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}/answers`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify(answer),
-      }
-    );
-    // console.log("postAnswer response", response);
-    if (!response.ok) {
-      throw new Error(
-        `${response.status} ${response.statusText} : postAnswer failed`
-      );
-    }
-    const data = await response.json();
-    // console.log("postAnswer data", data);
-    return data;
-  };
-
   const queryClient = useQueryClient();
 
   const addAnswerMutation = useMutation({
-    mutationFn: postAnswer,
-    // onMutate: () => {},
+    mutationFn: () => postAnswer(questionId, answer),
     onSuccess: () => {
-      // Invalidate the Query Key
-      // queryClient.invalidateQueries({ queryKey: ["question", questionId] });
-      // Refetch the Query Key
       queryClient.refetchQueries(["question", questionId]);
-      // Reset the Answer State
       setAnswer({
         situation: "",
         task: "",
@@ -95,12 +67,10 @@ const AddAnswerForm = ({ questionId, setShowAddAnswerForm }) => {
         action: undefined,
         result: undefined,
       });
-      // setTimeout(() => {
-      //   setShowAddAnswerForm((prev) => !prev);
-      // }, 1500);
+      setTimeout(() => {
+        setShowAddAnswerForm((prev) => !prev);
+      }, 1000);
     },
-    // onError: () => {},
-    // onSettled: () => {},
   });
 
   const { isPending, isError, error, isSuccess } = addAnswerMutation;

--- a/client/src/components/AddCommentForm.jsx
+++ b/client/src/components/AddCommentForm.jsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import SmsIcon from "@mui/icons-material/Sms";
 import SendIcon from "@mui/icons-material/Send";
+import postComment from "../api/postComment";
 import {
   consistentBorder,
   consistentBorderRadius,
@@ -31,50 +32,18 @@ const AddCommentForm = ({ questionId, answerId, setShowAddCommentForm }) => {
     );
   };
 
-  const postComment = async () => {
-    const response = await fetch(
-      `${
-        import.meta.env.VITE_SERVER_URL
-      }/api/questions/${questionId}/answers/${answerId}/comments`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({ comment }),
-      }
-    );
-    // console.log("postComment response", response);
-    if (!response.ok) {
-      throw new Error(
-        `${response.status} ${response.statusText} : postComment failed`
-      );
-    }
-    const data = await response.json();
-    // console.log("postComment data", data);
-    return data;
-  };
-
   const queryClient = useQueryClient();
 
   const addCommentMutation = useMutation({
-    mutationFn: postComment,
-    // onMutate: () => {},
+    mutationFn: () => postComment(questionId, answerId, comment),
     onSuccess: () => {
-      // Invalidate the Query Key
-      // queryClient.invalidateQueries({ queryKey: ["question", questionId] });
-      // Refetch the Query Key
       queryClient.refetchQueries(["question", questionId]);
-      // Reset the Comment State
       setComment("");
       setCommentValidation(undefined);
       // setTimeout(() => {
-      //   setShowAddAnswerForm((prev) => !prev);
-      // }, 1500);
+      //   setShowAddCommentForm((prev) => !prev);
+      // }, 1000);
     },
-    // onError: () => {},
-    // onSettled: () => {},
   });
 
   const { isPending, isError, error, isSuccess } = addCommentMutation;

--- a/client/src/components/AddQuestionForm.jsx
+++ b/client/src/components/AddQuestionForm.jsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import HelpOutlinedIcon from "@mui/icons-material/HelpOutlined";
 import SendIcon from "@mui/icons-material/Send";
+import postQuestion from "../api/postQuestion";
 import {
   consistentBorder,
   consistentBorderRadius,
@@ -31,40 +32,17 @@ const AddQuestionForm = ({ setShowAddQuestionForm }) => {
     );
   };
 
-  const postQuestion = async () => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-        body: JSON.stringify({ question }),
-      }
-    );
-    // console.log("postQuestion response", response);
-    if (!response.ok) {
-      throw new Error(
-        `${response.status} ${response.statusText} : postQuestion failed`
-      );
-    }
-    const data = await response.json();
-    // console.log("postQuestion data", data);
-    return data;
-  };
-
   const queryClient = useQueryClient();
 
   const addQuestionMutation = useMutation({
-    mutationFn: postQuestion,
+    mutationFn: () => postQuestion(question),
     onSuccess: () => {
       queryClient.refetchQueries(["questions"]);
       setQuestion("");
       setQuestionValidation(undefined);
       setTimeout(() => {
         setShowAddQuestionForm((prev) => !prev);
-      }, 1500);
+      }, 1000);
     },
   });
 
@@ -162,7 +140,7 @@ const AddQuestionForm = ({ setShowAddQuestionForm }) => {
                 border={consistentBorder}
                 borderRadius={consistentBorderRadius}
                 bgcolor={consistentBgColor}>
-                ✅ Your Comment was successfully added! Thank you
+                ✅ Your Question was successfully added! Thank you
               </Typography>
             )}
             {isError && (

--- a/client/src/components/Answer.jsx
+++ b/client/src/components/Answer.jsx
@@ -5,7 +5,7 @@ import ArrowForwardIosRoundedIcon from "@mui/icons-material/ArrowForwardIosRound
 import SmsOutlinedIcon from "@mui/icons-material/SmsOutlined";
 import AddCommentForm from "./AddCommentForm";
 import Comment from "./Comment";
-import { formatDate } from "../utils/formatDate";
+import formatDate from "../utils/formatDate";
 import {
   consistentBorder,
   consistentBorderRadius,

--- a/client/src/components/Comment.jsx
+++ b/client/src/components/Comment.jsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import MessageRoundedIcon from "@mui/icons-material/MessageRounded";
-import { formatDate } from "../utils/formatDate";
+import formatDate from "../utils/formatDate";
 import {
   consistentBorder,
   consistentBorderRadius,

--- a/client/src/components/EditQuestionForm.jsx
+++ b/client/src/components/EditQuestionForm.jsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import SaveAsRoundedIcon from "@mui/icons-material/SaveAsRounded";
+import putQuestion from "../api/putQuestion";
 import {
   consistentBackdropFilter,
   consistentBgColor,
@@ -31,33 +32,10 @@ const EditQuestionForm = ({ questionId, originalQuestion, setIsEditing }) => {
     );
   };
 
-  const putQuestion = async () => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}`,
-      {
-        method: "PUT",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ question: editedQuestion }),
-      }
-    );
-    // console.log("putQuestion response:", response);
-    if (!response.ok) {
-      throw new Error(
-        `${response.status} ${response.statusText} : editedQuestion failed`
-      );
-    }
-    const data = await response.json();
-    // console.log("putQuestion data:", data);
-    return data;
-  };
-
   const queryClient = useQueryClient();
 
   const editQuestionMutation = useMutation({
-    mutationFn: putQuestion,
+    mutationFn: () => putQuestion(questionId, editedQuestion),
     onSuccess: () => {
       queryClient.refetchQueries(["question", questionId]);
       setEditedQuestionValidation(undefined);

--- a/client/src/components/Question.jsx
+++ b/client/src/components/Question.jsx
@@ -1,12 +1,15 @@
 import { useContext, useState } from "react";
-import { Link as RouterLink } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLocation, useNavigate, Link as RouterLink } from "react-router-dom";
 import { Box, Typography, Button, Link, IconButton } from "@mui/material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import RateReviewOutlinedIcon from "@mui/icons-material/RateReviewOutlined";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { AuthContext } from "../context/AuthContext";
-import { formatDate } from "../utils/formatDate";
+import EditQuestionForm from "./EditQuestionForm";
+import deleteQuestion from "../api/deleteQuestion";
+import formatDate from "../utils/formatDate";
 import {
   consistentBorder,
   consistentBorderRadius,
@@ -15,43 +18,57 @@ import {
   consistentBackdropFilter,
   consistentLinkColor,
 } from "../themes/ConsistentStyles";
-import EditQuestionForm from "./EditQuestionForm";
 
 const Question = ({
   questionData,
-  questionAsLink,
   showAddAnswerForm,
   setShowAddAnswerForm,
 }) => {
-  // get the userCookie from AuthContext
+  console.log("Question questionData:", questionData);
+
   const { userCookie } = useContext(AuthContext);
+
   const [isEditing, setIsEditing] = useState(false);
 
   const handleEdit = async () => {
     setIsEditing(true);
   };
 
-  // TO DO: Convert this to use TanStack Query Mutations
-  const handleDelete = async (questionId) => {
-    try {
-      const response = await fetch(
-        `${import.meta.env.VITE_SERVER_URL}/api/questions/${questionId}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-      // console.log("handleDelete response:", response);
-      if (!response.ok) {
-        throw new Error("Failed to delete question");
-      }
-      const data = await response.json();
-      console.log("handleDelete data:", data);
+  const location = useLocation();
 
-      // TO DO: We need to Synchronise State HERE!
-    } catch (error) {
-      console.error("Error deleting question:", error.message);
-    }
+  let currentPage;
+  if (location.pathname.includes("/questions/")) {
+    currentPage = "individualQuestionPage";
+  } else if (location.pathname.includes("/questions")) {
+    currentPage = "allQuestionsPage";
+  } else if (location.pathname.includes("/profile")) {
+    currentPage = "profilePage";
+  }
+
+  const questionId = questionData.id;
+
+  const queryClient = useQueryClient();
+
+  const navigate = useNavigate();
+
+  const deleteQuestionMutation = useMutation({
+    mutationFn: () => deleteQuestion(questionId),
+    onError: (error) => {
+      console.log("deleteQuestionMutation onError");
+      console.error(error);
+    },
+    onSuccess: () => {
+      if (currentPage === "allQuestionsPage" || currentPage === "profilePage") {
+        queryClient.refetchQueries(["questions"]);
+      } else if (currentPage === "individualQuestionPage") {
+        queryClient.removeQueries(["question", questionId]);
+        navigate("/questions");
+      }
+    },
+  });
+
+  const handleDelete = async () => {
+    deleteQuestionMutation.mutate();
   };
 
   return (
@@ -72,9 +89,23 @@ const Question = ({
             <Typography variant={"questiontitle"} color="primary">
               Question
             </Typography>
-            <Typography variant={"body2"}>(id: {questionData.id})</Typography>
+            <Typography variant={"body2"}>| id: {questionData.id}</Typography>
             <Typography variant={"body2"}>
-              by userId: {questionData.userId}
+              | by userId: {questionData.userId}
+            </Typography>
+            <Typography variant={"body2"}>
+              | Answers (
+              {questionData?.answers?.length
+                ? questionData.answers.length
+                : "x"}
+              )
+            </Typography>
+            <Typography variant={"body2"}>
+              | Comments (
+              {questionData?.answers?.comments?.length
+                ? questionData?.answers?.comments?.length
+                : "x"}
+              )
             </Typography>
             <Box marginLeft={"auto"}>
               {questionData.userId === userCookie.id && (
@@ -94,24 +125,28 @@ const Question = ({
             </Box>
           </Box>
           <Box mt={1}>
-            {isEditing ? (
+            {!isEditing &&
+              (currentPage === "allQuestionsPage" ||
+                currentPage === "profilePage") && (
+                <Link
+                  component={RouterLink}
+                  to={`/questions/${questionData.id}`}
+                  color={consistentLinkColor}
+                  variant="questionbody">
+                  {questionData.question}
+                </Link>
+              )}
+            {!isEditing && currentPage === "individualQuestionPage" && (
+              <Typography variant={"questionbody"}>
+                {questionData.question}
+              </Typography>
+            )}
+            {isEditing && (
               <EditQuestionForm
                 questionId={questionData.id}
                 originalQuestion={questionData.question}
                 setIsEditing={setIsEditing}
               />
-            ) : questionAsLink ? (
-              <Link
-                component={RouterLink}
-                to={`/questions/${questionData.id}`}
-                color={consistentLinkColor}
-                variant="questionbody">
-                {questionData.question}
-              </Link>
-            ) : (
-              <Typography variant={"questionbody"}>
-                {questionData.question}
-              </Typography>
             )}
           </Box>
           <Box
@@ -120,7 +155,7 @@ const Question = ({
             flexWrap={"wrap"}
             gap={1}>
             <Box>
-              {!questionAsLink && (
+              {currentPage === "individualQuestionPage" && (
                 <Box mt={1}>
                   <Button
                     variant="outlined"

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -6,7 +6,7 @@ import {
   useMemo,
 } from "react";
 import { useNavigate } from "react-router-dom";
-import { getCookieValue } from "../utils/getCookieValue";
+import getCookieValue from "../utils/getCookieValue";
 
 export const AuthContext = createContext();
 

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -96,7 +96,6 @@ const ProfilePage = () => {
                   <Question
                     key={userQuestionData.id}
                     questionData={userQuestionData}
-                    currentPage={"profilePage"}
                   />
                 );
               })}

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -5,6 +5,7 @@ import { AuthContext } from "../context/AuthContext";
 import Loading from "../components/Loading";
 import Error from "../components/Loading";
 import Question from "../components/Question";
+import getAllQuestionsByUserId from "../api/getAllQuestionsByUserId";
 import { consistentPageBackgroundImage } from "../themes/ConsistentStyles";
 
 const ProfilePage = () => {
@@ -13,20 +14,6 @@ const ProfilePage = () => {
 
   const userId = userCookie.id;
 
-  const fetchUserQuestions = async (id) => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions/user/${id}`,
-      { credentials: "include" }
-    );
-    // console.log("fetchUserQuestions response:", response);
-    if (!response.ok) {
-      throw new Error("fetchUserQuestions failed");
-    }
-    const data = await response.json();
-    // console.log("fetchUserQuestions data:", data);
-    return data;
-  };
-
   const {
     isPending,
     isError,
@@ -34,7 +21,7 @@ const ProfilePage = () => {
     data: userQuestionsData,
   } = useQuery({
     queryKey: ["questions", "user", userId],
-    queryFn: () => fetchUserQuestions(userId),
+    queryFn: () => getAllQuestionsByUserId(userId),
   });
 
   return (
@@ -109,7 +96,7 @@ const ProfilePage = () => {
                   <Question
                     key={userQuestionData.id}
                     questionData={userQuestionData}
-                    questionAsLink={true}
+                    currentPage={"profilePage"}
                   />
                 );
               })}

--- a/client/src/pages/QuestionPage.jsx
+++ b/client/src/pages/QuestionPage.jsx
@@ -45,7 +45,6 @@ const QuestionPage = () => {
           <Box display={"grid"} gap={2}>
             <Question
               questionData={questionData}
-              currentPage={"questionPage"}
               showAddAnswerForm={showAddAnswerForm}
               setShowAddAnswerForm={setShowAddAnswerForm}
             />

--- a/client/src/pages/QuestionPage.jsx
+++ b/client/src/pages/QuestionPage.jsx
@@ -7,25 +7,12 @@ import Error from "../components/Loading";
 import Question from "../components/Question";
 import AddAnswerForm from "../components/AddAnswerForm";
 import Answer from "../components/Answer";
+import getQuestionById from "../api/getQuestionById";
 import { consistentPageBackgroundImage } from "../themes/ConsistentStyles";
 
 const QuestionPage = () => {
   const { id } = useParams();
   const [showAddAnswerForm, setShowAddAnswerForm] = useState(false);
-
-  const fetchQuestion = async (id) => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions/${id}`,
-      { credentials: "include" }
-    );
-    // console.log("fetchQuestionData response:", response);
-    if (!response.ok) {
-      throw new Error("fetchQuestion failed");
-    }
-    const data = await response.json();
-    // console.log("fetchQuestionData data:", data);
-    return data;
-  };
 
   const {
     isPending,
@@ -34,7 +21,7 @@ const QuestionPage = () => {
     data: questionData,
   } = useQuery({
     queryKey: ["question", id],
-    queryFn: () => fetchQuestion(id),
+    queryFn: () => getQuestionById(id),
   });
 
   return (
@@ -58,6 +45,7 @@ const QuestionPage = () => {
           <Box display={"grid"} gap={2}>
             <Question
               questionData={questionData}
+              currentPage={"questionPage"}
               showAddAnswerForm={showAddAnswerForm}
               setShowAddAnswerForm={setShowAddAnswerForm}
             />

--- a/client/src/pages/QuestionsPage.jsx
+++ b/client/src/pages/QuestionsPage.jsx
@@ -54,11 +54,7 @@ const QuestionsPage = () => {
           )}
           <Box display={"grid"} gap={2} mt={1}>
             {allQuestionsData.map((questionData) => (
-              <Question
-                key={questionData.id}
-                questionData={questionData}
-                currentPage={"questionsPage"}
-              />
+              <Question key={questionData.id} questionData={questionData} />
             ))}
           </Box>
         </Box>

--- a/client/src/pages/QuestionsPage.jsx
+++ b/client/src/pages/QuestionsPage.jsx
@@ -5,24 +5,11 @@ import Loading from "../components/Loading";
 import Error from "../components/Loading";
 import Question from "../components/Question";
 import AddQuestionForm from "../components/AddQuestionForm";
+import getAllQuestions from "../api/getAllQuestions";
 import { consistentPageBackgroundImage } from "../themes/ConsistentStyles";
 
 const QuestionsPage = () => {
   const [showAddQuestionForm, setShowAddQuestionForm] = useState(false);
-
-  const fetchAllQuestions = async () => {
-    const response = await fetch(
-      `${import.meta.env.VITE_SERVER_URL}/api/questions`,
-      { credentials: "include" }
-    );
-    // console.log("fetchAllQuestionsData response:", response);
-    if (!response.ok) {
-      throw new Error("fetchAllQuestions failed");
-    }
-    const data = await response.json();
-    // console.log("fetchAllQuestionsData data:", data);
-    return data;
-  };
 
   const {
     isPending,
@@ -31,7 +18,7 @@ const QuestionsPage = () => {
     data: allQuestionsData,
   } = useQuery({
     queryKey: ["questions"],
-    queryFn: fetchAllQuestions,
+    queryFn: getAllQuestions,
   });
 
   return (
@@ -70,7 +57,7 @@ const QuestionsPage = () => {
               <Question
                 key={questionData.id}
                 questionData={questionData}
-                questionAsLink={true}
+                currentPage={"questionsPage"}
               />
             ))}
           </Box>

--- a/client/src/utils/formatDate.js
+++ b/client/src/utils/formatDate.js
@@ -1,4 +1,4 @@
-export const formatDate = (date) => {
+const formatDate = (date) => {
   date = new Date(date);
   const now = new Date();
   const difference = now - date;

--- a/client/src/utils/formatDate.js
+++ b/client/src/utils/formatDate.js
@@ -35,3 +35,5 @@ export const formatDate = (date) => {
     }${minutes}${ampm}`;
   }
 };
+
+export default formatDate;

--- a/client/src/utils/getCookieValue.js
+++ b/client/src/utils/getCookieValue.js
@@ -1,4 +1,4 @@
-export const getCookieValue = (cookieName) => {
+const getCookieValue = (cookieName) => {
   const cookieString = document.cookie;
   // console.log("cookieString:", cookieString);
 
@@ -37,3 +37,5 @@ export const getCookieValue = (cookieName) => {
 
   return null;
 };
+
+export default getCookieValue;


### PR DESCRIPTION
- created `client/src/api` folder
- abstracted away all `fetch()` into individual files and refactored with parameters
- imported them wherever they were used
- removed `isLink`/`isQuestionLink` prop from `Question` and use `location` from `react-router-dom` to establish which page we are in for conditional rendering inside `Question`
- changed utils to `export default`
- updated `EditQuestionForm`