### PR TITLE
STAR-123 .gitignore and .env fixes

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -10,7 +10,10 @@ lerna-debug.log*
 node_modules
 build
 dist
-.env
+*.env
+!*.env.example
+*.env.*
+!*.env.*.example
 dist-ssr
 *.local
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,3 +18,4 @@ GOOGLE_REDIRECT_URI=
 
 # the customJWT Signing Secret:
 JWT_SECRET=
+# Generate with "openssl rand -hex 32"

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,4 +18,4 @@ GOOGLE_REDIRECT_URI=
 
 # the customJWT Signing Secret:
 JWT_SECRET=
-# Generate with "openssl rand -hex 32"
+# Generate from the Command Line with "openssl rand -hex 32"

--- a/server/.env.test.example
+++ b/server/.env.test.example
@@ -1,12 +1,20 @@
 # the ENVironment that Node is running in:
 NODE_ENV=test
 
+# the Port the Express Server runs on:
+SERVER_PORT=
+
 # the Database Connection details:
 DATABASE_HOST=
 DATABASE_PORT=
 DATABASE_USER=
 DATABASE_PASSWORD=
 DATABASE_NAME=star_test
+
+# the Google Authentication details:
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
 
 # the customJWT Signing Secret:
 JWT_SECRET=

--- a/server/.env.test.example
+++ b/server/.env.test.example
@@ -7,4 +7,7 @@ DATABASE_PORT=
 DATABASE_USER=
 DATABASE_PASSWORD=
 DATABASE_NAME=star_test
-JWT_SECRET=abcdefg
+
+# the customJWT Signing Secret:
+JWT_SECRET=
+# Generate with "openssl rand -hex 32"

--- a/server/.env.test.example
+++ b/server/.env.test.example
@@ -18,4 +18,4 @@ GOOGLE_REDIRECT_URI=
 
 # the customJWT Signing Secret:
 JWT_SECRET=
-# Generate with "openssl rand -hex 32"
+# Generate from the Command Line with "openssl rand -hex 32"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 build
 dist
-.env*
+*.env
+!*.env.example
+*.env.*
+!*.env.*.example
 .DS_Store


### PR DESCRIPTION
1. fixed `.gitignore` patterns for `client` and `server`

- **ignore:**
  - `.env`
  - `.env.test`
  - `.env.production`

- **but do not ignore:**
  - `.env.example`
  - `.env.test.example`
  - `.env.production.example`

2. added instruction to generate JWT Secret from the Command Line into `.env.example`